### PR TITLE
Better collision visuals

### DIFF
--- a/circle-collision/src/lib.rs
+++ b/circle-collision/src/lib.rs
@@ -151,9 +151,6 @@ impl<'a> System<'a> for BruteForceCollisionDetector {
         let pdt = physics_delta.0.as_seconds();
         collisions.0.clear();
         for (e1, c1, p1, _) in (&*entities, &colliders, &positions, !&deleted).join() {
-            if !entities.is_alive(e1) {
-                println!("BFCD Ent {:?} is dead", e1);
-            }
             let v1 = velocities.get(e1).map_or(Vector::new(0., 0.), |v| v.linear);
             for (e2, c2, p2, _) in (&*entities, &colliders, &positions, !&deleted).join() {
                 // Enforce ordering to ensure we only generate one collision per pair. We would

--- a/gravity/src/lib.rs
+++ b/gravity/src/lib.rs
@@ -88,15 +88,9 @@ impl<'a> System<'a> for GravitySystem {
 
         for (ent, pos, _, _, acc)
             in (&*entities, &positions, &targets, !&deleted, &mut forces).join() {
-            if !entities.is_alive(ent) {
-                println!("Grav Ent {:?} is dead", ent);
-            }
             let mass = masses.get(ent).cloned().unwrap_or_default().linear;
             for (source_ent, source_pos, _, _) 
                 in (&*entities, &positions, &sources, !&deleted).join() {
-                if !entities.is_alive(source_ent) {
-                    println!("Grav Ent {:?} is dead", ent);
-                }
                 if ent == source_ent { continue; }
                 let source_mass = masses.get(source_ent).cloned().unwrap_or_default().linear;
                 let force_dir = source_pos.pos() - pos.pos();

--- a/saver_genetic_orbits/src/collision.rs
+++ b/saver_genetic_orbits/src/collision.rs
@@ -29,6 +29,7 @@ use specs::{
 
 use xsecurelock_saver::engine::{
     components::{
+        delete::Deleted,
         draw::{
             DrawColor,
             DrawShape,
@@ -219,11 +220,12 @@ impl<'a> System<'a> for DeleteCollidedPlanets {
     type SystemData = (
         Entities<'a>,
         ReadStorage<'a, MergedInto>,
+        WriteStorage<'a, Deleted>,
     );
 
-    fn run(&mut self, (entities, successors): Self::SystemData) {
+    fn run(&mut self, (entities, successors, mut deleted): Self::SystemData) {
         for (ent, _) in (&*entities, &successors).join() {
-            entities.delete(ent).unwrap();
+            deleted.insert(ent, Deleted).unwrap();
         }
     }
 }

--- a/saver_genetic_orbits/src/main.rs
+++ b/saver_genetic_orbits/src/main.rs
@@ -43,6 +43,7 @@ use gravity::{
 };
 use circle_collision::{
     BruteForceCollisionDetector,
+    ClearCollisionsInvolvingSceneEntities,
     CircleCollider,
     CollisionMatrix,
     LastUpdateCollisions,
@@ -102,6 +103,7 @@ fn main() {
         .with_component::<GravitySource>()
         .with_component::<GravityTarget>()
         .with_component::<MergedInto>()
+        .with_scene_change_sys(ClearCollisionsInvolvingSceneEntities, "", &[])
         // Run scorekeeping during the first stage of physics updates.
         .with_physics_update_sys(ScoreKeeper::<SqliteStorage>::default(), "score-keeper", &[])
         .with_physics_update_sys(GravitySystem, "apply-gravity", &[])

--- a/saver_genetic_orbits/src/statustracker.rs
+++ b/saver_genetic_orbits/src/statustracker.rs
@@ -24,9 +24,12 @@ use specs::{
 };
 
 use xsecurelock_saver::engine::{
-    components::physics::{
-        Mass,
-        Position,
+    components::{
+        delete::Deleted,
+        physics::{
+            Mass,
+            Position,
+        },
     },
     resources::{
         draw::View,
@@ -74,6 +77,7 @@ impl<'a, T> System<'a> for ScoreKeeper<T> where T: Storage + Default + Send + Sy
         Write<'a, SceneChange>,
         ReadStorage<'a, Position>,
         ReadStorage<'a, Mass>,
+        ReadStorage<'a, Deleted>,
     );
 
     fn run(
@@ -86,6 +90,7 @@ impl<'a, T> System<'a> for ScoreKeeper<T> where T: Storage + Default + Send + Sy
             mut scene_change,
             positions,
             masses,
+            deleted,
         ): Self::SystemData,
     ) {
         if world_track.ticks_completed < scoring.scored_ticks {
@@ -100,7 +105,7 @@ impl<'a, T> System<'a> for ScoreKeeper<T> where T: Storage + Default + Send + Sy
 
             let mut mass_count = 0f64;
             let mut total_mass = 0f64;
-            for (position, mass) in (&positions, &masses).join() {
+            for (position, mass, _) in (&positions, &masses, !&deleted).join() {
                 let pos = position.pos();
                 if pos.x.abs() <= horizontal_half_extent && pos.y.abs() <= vertical_half_extent {
                     mass_count += 1.;

--- a/src/engine/components/delete.rs
+++ b/src/engine/components/delete.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use specs::{Component, NullStorage, World};
+
+pub(crate) fn register_all(world: &mut World) {
+    world.register::<Deleted>();
+}
+
+/// A component which marks an object as deleted. Will be cleaned up at the end of the current
+/// dispatcher run before the next call to maintain.
+/// This is useful because Entities.delete(ent) does not apply until the next call to maintain, but
+/// there's no way to query for deleted entities. If systems want to delete entities early and let
+/// other systems see that the entities are meant to be deleted before the next call to maintain,
+/// they can use this.
+#[derive(Default)]
+pub struct Deleted;
+impl Component for Deleted { type Storage = NullStorage<Self>; }

--- a/src/engine/components/mod.rs
+++ b/src/engine/components/mod.rs
@@ -14,11 +14,13 @@
 
 use specs::World;
 
+pub mod delete;
 pub mod draw;
 pub mod physics;
 pub mod scene;
 
 pub(crate) fn register_all(world: &mut World) {
+    delete::register_all(world);
     draw::register_all(world);
     physics::register_all(world);
     scene::register_all(world);

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -45,6 +45,7 @@ use self::{
         },
     },
     systems::{
+        delete::DeleteSystem,
         draw::{
             DrawLayersUpdater,
             SyncDrawShapesSystem,
@@ -218,12 +219,17 @@ impl<'a, 'b> EngineBuilder<'a, 'b> {
             update_dispatcher: self.update_dispatcher
                 .with_barrier()
                 .with(DrawLayersUpdater::default(), "", &[])
+                .with(DeleteSystem, "", &[])
                 .build(),
             scene_change_dispatcher: self.scene_change_dispatcher
                 .with_barrier()
+                .with(DeleteSystem, "", &[])
                 .with(ClearCurrentScene, "", &[])
                 .build(),
-            physics_update_dispatcher: self.physics_update_dispatcher.build(),
+            physics_update_dispatcher: self.physics_update_dispatcher
+                .with_barrier()
+                .with(DeleteSystem, "", &[])
+                .build(),
 
             window: super::open_window(),
             view: SfView::new(Vector2f::new(0., 0.), Vector2f::new(1., 1.)),

--- a/src/engine/systems/delete.rs
+++ b/src/engine/systems/delete.rs
@@ -1,0 +1,22 @@
+use specs::{
+    Entities,
+    Join,
+    ReadStorage,
+    System,
+};
+
+use engine::components::delete::Deleted;
+
+pub(crate) struct DeleteSystem;
+impl<'a> System<'a> for DeleteSystem {
+    type SystemData = (
+        Entities<'a>,
+        ReadStorage<'a, Deleted>,
+    );
+
+    fn run(&mut self, (entities, deleted): Self::SystemData) {
+        for (ent, _) in (&*entities, &deleted).join() {
+            entities.delete(ent).unwrap();
+        }
+    }
+}

--- a/src/engine/systems/mod.rs
+++ b/src/engine/systems/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod delete;
 pub mod draw;
 pub mod physics;
 pub mod scene;

--- a/src/engine/systems/scene.rs
+++ b/src/engine/systems/scene.rs
@@ -15,29 +15,22 @@
 use specs::{
     Entities,
     Join,
-    Read,
     ReadStorage,
     System,
 };
 
-use engine::{
-    components::scene::InScene,
-    resources::scene::SceneChange,
-};
+use engine::components::scene::InScene;
 
 pub struct ClearCurrentScene;
 impl<'a> System<'a> for ClearCurrentScene {
     type SystemData = (
         Entities<'a>,
         ReadStorage<'a, InScene>,
-        Read<'a, SceneChange>,
     );
 
-    fn run(&mut self, (entities, in_scene, scene_change): Self::SystemData) {
-        if scene_change.is_scene_change_scheduled() {
-            for (entity, _) in (&*entities, &in_scene).join() {
-                entities.delete(entity).unwrap();
-            }
+    fn run(&mut self, (entities, in_scene): Self::SystemData) {
+        for (entity, _) in (&*entities, &in_scene).join() {
+            entities.delete(entity).unwrap();
         }
     }
 }


### PR DESCRIPTION
Changed so that graphics interpolation happens before planets are merged and deleted. Actually shouldn't affect scorekeeping.

This might marginally affect the positions of merged planets, since the move integration step now happens after collision detection but before merging.

Fixes #6 