### PR TITLE
Reward planet count

### DIFF
--- a/saver_genetic_orbits/src/config/scoring.rs
+++ b/saver_genetic_orbits/src/config/scoring.rs
@@ -15,6 +15,7 @@
 //! Contains configuration structs for the scoring system.
 
 use config::{Validation, fix_invalid_helper};
+use statustracker::scoring_function::Expression;
 
 /// Tuning parameters for world scoring.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -26,6 +27,10 @@ pub struct ScoringConfig {
 
     /// The region where planets actually count towards the scenario score.
     pub scored_area: ScoredArea,
+
+    /// Expression that is evaluated each frame to determine the score for that frame, to be added
+    /// to the cumulative score. I'm sorry for using yaml lists as s-expressions.
+    pub per_frame_scoring_expression: Expression,
 }
 
 impl Default for ScoringConfig {
@@ -34,6 +39,9 @@ impl Default for ScoringConfig {
             // 1 minute (60,000 milliseconds) / 16 milliseconds per tick
             scored_ticks: 3750,
             scored_area: Default::default(),
+            per_frame_scoring_expression: Expression::Multiply(
+                vec![Expression::TotalMass, Expression::MassCount],
+            ),
         }
     }
 }
@@ -47,6 +55,7 @@ impl Validation for ScoringConfig {
             || Self::default().scored_ticks,
         );
         self.scored_area.fix_invalid(&[path, "scored_area"].join("."));
+        // no validation for per_frame_scoring.
     }
 }
 

--- a/saver_genetic_orbits/src/statustracker/mod.rs
+++ b/saver_genetic_orbits/src/statustracker/mod.rs
@@ -42,6 +42,8 @@ use model::{Scenario, World};
 use storage::Storage;
 use worldgenerator::WorldGenerator;
 
+pub mod scoring_function;
+
 /// Resource for tracking the status of the currently active scene.
 pub struct ActiveWorld {
     /// The world being scored.
@@ -112,7 +114,8 @@ impl<'a, T> System<'a> for ScoreKeeper<T> where T: Storage + Default + Send + Sy
                     total_mass += mass.linear as f64
                 }
             }
-            world_track.cumulative_score += total_mass * mass_count;
+            world_track.cumulative_score += scoring.per_frame_scoring_expression
+                .eval(world_track.ticks_completed as f64, total_mass, mass_count);
             world_track.ticks_completed += 1;
         } else {
             info!("Storing scored world");

--- a/saver_genetic_orbits/src/statustracker/scoring_function.rs
+++ b/saver_genetic_orbits/src/statustracker/scoring_function.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Expression for computing the per-frame score for a scene from that frame's total mass and total
 /// mass count and the tick count.
 // TODO(zstewar1): Find a better way to handle parsing. S-expressions as a yaml string?

--- a/saver_genetic_orbits/src/statustracker/scoring_function.rs
+++ b/saver_genetic_orbits/src/statustracker/scoring_function.rs
@@ -1,0 +1,67 @@
+/// Expression for computing the per-frame score for a scene from that frame's total mass and total
+/// mass count and the tick count.
+// TODO(zstewar1): Find a better way to handle parsing. S-expressions as a yaml string?
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum Expression {
+    /// The current tick.
+    Tick,
+    /// The total mass for the frame.
+    TotalMass,
+    /// The number of masses for the frame.
+    MassCount,
+    /// A floating point constant.
+    Constant(f64),
+    /// The product of a series of expressions.
+    Multiply(Vec<Expression>),
+    /// The sum of a series of expressions.
+    Add(Vec<Expression>),
+    /// A series of expressions raised to the power of each next one.
+    Power(Vec<Expression>),
+    /// A series of expressions subtracted from each other *or* the negation of the single input
+    /// expression.
+    Subtract(Vec<Expression>),
+    /// A series of expressions successively divided by each other.
+    Divide(Vec<Expression>),
+}
+
+impl Expression {
+    /// Evaluate the expression given the scoring function inputs.
+    pub fn eval(&self, tick: f64, total_mass: f64, mass_count: f64) -> f64 {
+        match self {
+            Expression::Tick => tick,
+            Expression::TotalMass => total_mass,
+            Expression::MassCount => mass_count,
+            Expression::Constant(value) => *value,
+            Expression::Multiply(ref subexprs) =>
+                fold_eval(tick, total_mass, mass_count, subexprs, |acc, next| acc * next),
+            Expression::Add(ref subexprs) => if subexprs.len() == 1 {
+                subexprs[0].eval(tick, total_mass, mass_count)
+            } else {
+                fold_eval(tick, total_mass, mass_count, subexprs, |acc, next| acc + next)
+            },
+            Expression::Power(ref subexprs) =>
+                fold_eval(tick, total_mass, mass_count, subexprs, |acc, next| acc.powf(next)),
+            Expression::Subtract(ref subexprs) => if subexprs.len() == 1 {
+                -subexprs[0].eval(tick, total_mass, mass_count)
+            } else {
+                fold_eval(tick, total_mass, mass_count, subexprs, |acc, next| acc - next)
+            },
+            Expression::Divide(ref subexprs) =>
+                fold_eval(tick, total_mass, mass_count, subexprs, |acc, next| acc / next),
+        }
+    }
+}
+
+fn fold_eval<F>(
+    tick: f64, total_mass: f64, mass_count: f64,
+    items: &[Expression],
+    mut func: F,
+) -> f64
+    where F: FnMut(f64, f64) -> f64,
+{
+    assert!(items.len() >= 2);
+    let mut iter = items.iter();
+    let first = iter.next().unwrap().eval(tick, total_mass, mass_count);
+    iter.fold(first, |acc, next| func(acc, next.eval(tick, total_mass, mass_count)))
+}


### PR DESCRIPTION
Fixes #7 

Add a simple expression tree which is used to compute the per-frame score. This currently just uses the Yaml parser with serde default enum encoding, meaning that expressions are ugly pseudo s-exprs using yaml lists, e.g.: `{"multiply": ["mass_count", {"constant": 3.5}]}`. This is good enough for now, and I'll open a new issue to do fancier parsing later.